### PR TITLE
Enhance GPS Listener to handle delayed and out-of-order pings

### DIFF
--- a/app/etaengine/src/main/java/com/ivez/etaengine/service/BusStateTracker.java
+++ b/app/etaengine/src/main/java/com/ivez/etaengine/service/BusStateTracker.java
@@ -4,6 +4,7 @@ import com.ivez.etaengine.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -135,4 +136,10 @@ public class BusStateTracker {
 
         return haversine(px, py, projX, projY);
     }
+
+    public boolean isNewer(BusPing ping){
+        BusState latest = stateMap.get(ping.getBusId());
+        return latest == null || ping.getTimestamp() > latest.getLastUpdated();
+    }
+
 }


### PR DESCRIPTION
- Stale Pings are now ignored if we have a more recent ping
- Delay tolerance of 2 mins have been setup and pings with delay more than that are discarded.